### PR TITLE
Refactor-버튼 컴포넌트 ui 개선합니다

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -52,6 +52,7 @@ export const PrimaryLarge: Story = {
     variant: 'primary',
     size: 'lg',
     rounded: 'md',
+    className: 'w-full',
   },
 };
 
@@ -61,5 +62,35 @@ export const PrimaryMedium: Story = {
     variant: 'primary',
     size: 'md',
     rounded: 'md',
+  },
+};
+
+export const SecondaryLarge: Story = {
+  args: {
+    children: '계속하기',
+    variant: 'secondary',
+    size: 'lg',
+    rounded: 'md',
+    className: 'w-full',
+  },
+};
+
+export const DropDown: Story = {
+  args: {
+    children: '카테고리',
+    variant: 'primary',
+    size: 'md',
+    rounded: 'full',
+    icon: 'chevron-down',
+  },
+};
+
+export const Plus: Story = {
+  args: {
+    children: '방 생성',
+    variant: 'primary',
+    size: 'lg',
+    rounded: 'full',
+    icon: 'plus',
   },
 };

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,16 +2,18 @@ import {
   Button as HeadlessButton,
   ButtonProps as HeadlessButtonProps,
 } from '@headlessui/react';
+import { ChevronDownIcon, PlusIcon } from '@heroicons/react/24/outline';
 import { cva, VariantProps } from 'class-variance-authority';
 import React from 'react';
 import { cn } from '~/utils/classname';
 
 const ButtonVariant = cva(
-  'inline-block w-full text-center font-bold text-white transition duration-300 data-[hover]:scale-95 data-[disabled]:cursor-not-allowed data-[disabled]:bg-gray-5 data-[active]:opacity-70 data-[hover]:opacity-90 data-[focus]:outline-none',
+  'inline-block text-center font-bold text-white transition duration-300 data-[hover]:scale-95 data-[disabled]:cursor-not-allowed data-[disabled]:bg-gray-5 data-[active]:opacity-70 data-[hover]:opacity-90 data-[focus]:outline-none',
   {
     variants: {
       variant: {
         primary: 'bg-red',
+        s차econdary: 'bg-sub',
       },
       rounded: {
         full: 'rounded-full',
@@ -20,6 +22,11 @@ const ButtonVariant = cva(
       size: {
         lg: 'h-12 px-4 py-2.5 text-xl',
         md: 'h-11 w-fit p-2.5 text-base',
+        sm: 'h-9 py-2.5 text-base',
+      },
+      icon: {
+        'chevron-down': 'flex items-center gap-x-1 px-4',
+        plus: 'flex flex-row-reverse items-center gap-x-1 text-xl',
       },
     },
     defaultVariants: {
@@ -30,16 +37,39 @@ const ButtonVariant = cva(
   },
 );
 
-type ButtonProps = Readonly<
-  HeadlessButtonProps & VariantProps<typeof ButtonVariant>
+type ButtonIcon = Uppercase<
+  NonNullable<VariantProps<typeof ButtonVariant>['icon']>
 >;
 
-const Button: React.FC<ButtonProps> = ({ className, ...props }) => {
+const BUTTON_ICONS: Readonly<
+  Record<ButtonIcon, React.FC<React.ComponentProps<'svg'>>>
+> = {
+  'CHEVRON-DOWN': ChevronDownIcon,
+  PLUS: PlusIcon,
+};
+
+type ButtonProps = Readonly<
+  Omit<HeadlessButtonProps, 'children'> &
+    VariantProps<typeof ButtonVariant> &
+    React.PropsWithChildren
+>;
+
+const Button: React.FC<ButtonProps> = ({
+  className,
+  icon,
+  children,
+  ...props
+}) => {
+  const Icon = icon ? BUTTON_ICONS[icon.toUpperCase() as ButtonIcon] : null;
+
   return (
     <HeadlessButton
-      className={cn(ButtonVariant(props), className)}
+      className={cn(ButtonVariant({ icon, ...props }), className)}
       {...props}
-    />
+    >
+      {children}
+      {Icon && <Icon className="size-4.5 stroke-white stroke-2" />}
+    </HeadlessButton>
   );
 };
 


### PR DESCRIPTION
## 📌 PR Summary

Button에 icon prop으로 icon이 달린 버튼 ui 만들어지도록 수정했습니다.
이 외 variant prop 에 `secondary` 옵션으로 회색 배경인 버튼으로 바뀔 수 있도록 했습니다.

## 🤔 NOTE

화이팅.

## 🔗 Related Issues
 
#15 
