### PR TITLE
Feat-Dialog component 만듭니다

### DIFF
--- a/src/components/BrandModal.stories.tsx
+++ b/src/components/BrandModal.stories.tsx
@@ -1,0 +1,57 @@
+import { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import BrandModal from '~/components/BrandModal';
+import { Button } from '~/components/Button';
+
+const meta: Meta<typeof BrandModal> = {
+  title: 'Oranisms/BrandModal',
+  component: BrandModal,
+  tags: ['autodocs'],
+  args: {
+    className: '',
+  },
+  argTypes: {
+    className: {
+      description: 'The class name of the modal.',
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof BrandModal>;
+
+export const Default: Story = {
+  args: {
+    className: '',
+  },
+  render: (props) => {
+    const [visible, setVisible] = React.useState(false);
+
+    return (
+      <>
+        <Button onClick={() => setVisible(true)}>모달 열기 버튼</Button>
+
+        <BrandModal
+          {...props}
+          onClose={() => setVisible(false)}
+          hasBackdropBlur
+          visible={visible}
+        >
+          <BrandModal.Header>
+            <BrandModal.Title label="Title" />
+            <BrandModal.CloseButton position="right" />
+          </BrandModal.Header>
+
+          <BrandModal.Body>모달 내용입니다.</BrandModal.Body>
+
+          <BrandModal.ButtonGroup>
+            <BrandModal.Button kind="no">나가기</BrandModal.Button>
+            <BrandModal.Button kind="yes">남아있기</BrandModal.Button>
+          </BrandModal.ButtonGroup>
+        </BrandModal>
+      </>
+    );
+  },
+};

--- a/src/components/BrandModal.tsx
+++ b/src/components/BrandModal.tsx
@@ -1,0 +1,121 @@
+import {
+  Button as HeadlessButton,
+  ButtonProps as HeadlessButtonProps,
+} from '@headlessui/react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import React from 'react';
+import { Button as BrandButton } from '~/components/Button';
+import { cn } from '~/utils/classname';
+import Modal, { ModalProps } from './Modal';
+
+type BrandModalProps = Readonly<React.PropsWithChildren<ModalProps>>;
+
+const BrandModal: React.FC<BrandModalProps> = ({
+  className,
+  children,
+  ...props
+}) => {
+  return (
+    <Modal
+      className={cn('flex size-fit max-w-lg flex-col bg-gray-6', className)}
+      {...props}
+    >
+      {children}
+    </Modal>
+  );
+};
+
+type HeadeProps = Readonly<React.ComponentProps<'div'>>;
+
+const Header: React.FC<HeadeProps> = ({ className, ...props }) => {
+  return (
+    <div
+      className={cn(
+        'relative flex h-16 w-full items-center justify-center bg-gray-5',
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+type TitleProps = Readonly<
+  Omit<React.ComponentProps<'h1'>, 'children'> & {
+    label: string;
+  }
+>;
+
+const Title: React.FC<TitleProps> = ({ label, className, ...props }) => {
+  return (
+    <h1 className={cn('text-2xl font-bold', className)} {...props}>
+      {label}
+    </h1>
+  );
+};
+
+type CloseButtonProps = Readonly<
+  HeadlessButtonProps & {
+    position?: 'right' | 'left';
+  }
+>;
+
+const CloseButton: React.FC<CloseButtonProps> = ({
+  position = 'right',
+  className,
+  ...props
+}) => {
+  return (
+    <HeadlessButton
+      as={XMarkIcon}
+      className={cn(
+        'absolute size-6 cursor-pointer fill-gray-1 stroke-2',
+        position === 'right' ? 'right-4' : 'left-4',
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+type BodyProps = Readonly<React.ComponentProps<'div'>>;
+
+const Body: React.FC<BodyProps> = ({ className, ...props }) => {
+  return <div className={cn('p-4', className)} {...props} />;
+};
+
+type ButtonGroup = Readonly<React.ComponentProps<'div'>>;
+
+const ButtonGroup: React.FC<ButtonGroup> = ({ className, ...props }) => {
+  return (
+    <div
+      className={cn('flex items-center justify-center gap-x-8 p-5', className)}
+      {...props}
+    />
+  );
+};
+
+type ButtonProps = Readonly<
+  React.ComponentProps<typeof BrandButton> & {
+    kind: 'yes' | 'no';
+  }
+>;
+
+const Button: React.FC<ButtonProps> = ({ kind, ...props }) => {
+  return (
+    <BrandButton
+      variant={kind === 'yes' ? 'primary' : 'secondary'}
+      rounded="full"
+      size="lg"
+      {...props}
+    />
+  );
+};
+
+export default Object.assign(BrandModal, {
+  Header,
+  Title,
+  CloseButton,
+  Body,
+  ButtonGroup,
+  Button,
+});

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -26,7 +26,7 @@ const Modal: React.FC<React.PropsWithChildren<ModalProps>> = ({
 }) => {
   return (
     <Dialog
-      className="fixed inset-0 z-50 size-full"
+      className="fixed inset-0 z-50 flex size-full items-center justify-center"
       transition
       open={visible}
       onClose={onClose}


### PR DESCRIPTION
## 📌 PR Summary

Dialog 컴포넌트입니다.
스토리는 `Organisms/BrandModal` 입니다
<img width="335" alt="image" src="https://github.com/user-attachments/assets/4060a208-c4f7-45b8-aa41-b0ccbd719463" />


## 🤔 NOTE

Headlessui 처럼 compound component 패턴으로 개발했습니다.
다음과 같이 다양한 dialog ui 형태 조립해서 재사용가능하도록 했습니다.

```jsx
<BrandModal
  {...props}
  onClose={() => setVisible(false)}
  hasBackdropBlur
  visible={visible}
>
  <BrandModal.Header>
    <BrandModal.Title label="Title" />
    <BrandModal.CloseButton position="right" />
  </BrandModal.Header>

  <BrandModal.Body>모달 내용입니다.</BrandModal.Body>

  <BrandModal.ButtonGroup>
    <BrandModal.Button kind="no">나가기</BrandModal.Button>
    <BrandModal.Button kind="yes">남아있기</BrandModal.Button>
  </BrandModal.ButtonGroup>
</BrandModal>
```

## 🔗 Related Issues
 
#19 
