### PR TITLE
FEAT-입력컴포넌트를 생성한다.

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,5 +25,4 @@ const RootLayout: React.FC<RootLayoutProps> = ({ children }) => {
     </html>
   );
 };
-
 export default RootLayout;

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
 import Input from './Input';
 
 const meta: Meta<typeof Input> = {
@@ -13,10 +14,6 @@ const meta: Meta<typeof Input> = {
     },
     placeholder: {
       description: 'Input의 placeholder 텍스트',
-      control: 'text',
-    },
-    error: {
-      description: '에러 메시지',
       control: 'text',
     },
     className: {
@@ -64,6 +61,16 @@ export const TextInput: Story = {
     type: 'text',
     placeholder: 'Enter your text',
   },
+  render: () => {
+    const [value, setValue] = React.useState('');
+
+    return <Input value={value} onValueChange={handleValueChange} />;
+
+    function handleValueChange(newValue: string) {
+      console.log(newValue);
+      setValue(newValue);
+    }
+  },
 };
 
 export const PasswordInput: Story = {
@@ -84,7 +91,7 @@ export const TextareaInput: Story = {
   args: {
     type: 'textarea',
     placeholder: 'Enter your message',
-    className: 'h-32', // 텍스트 에어리어 높이 조정
+    className: 'h-32',
   },
 };
 
@@ -109,7 +116,6 @@ export const WithError: Story = {
   args: {
     type: 'text',
     placeholder: 'Input with error',
-    error: 'This field is required',
-    className: 'border-red-500', // 에러 시 빨간 테두리
+    className: 'border-red-500',
   },
 };

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -1,0 +1,115 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Input from './Input';
+
+const meta: Meta<typeof Input> = {
+  title: 'Atoms/Input',
+  component: Input,
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      description: 'Input 타입 (text, password, email, textarea)',
+      control: 'select',
+      options: ['text', 'password', 'email', 'textarea'],
+    },
+    placeholder: {
+      description: 'Input의 placeholder 텍스트',
+      control: 'text',
+    },
+    error: {
+      description: '에러 메시지',
+      control: 'text',
+    },
+    className: {
+      description: '커스텀 클래스를 추가할 수 있음',
+      control: false,
+    },
+    variant: {
+      description: 'Input 스타일',
+      control: 'select',
+      options: ['primary'],
+    },
+    rounded: {
+      description: 'Input 테두리 스타일',
+      control: 'select',
+      options: ['full', 'lg', 'md'],
+    },
+    size: {
+      description: 'Input 크기',
+      control: 'select',
+      options: ['lg', 'md', 'sm'],
+    },
+  },
+  args: {
+    type: 'text',
+    placeholder: 'Enter your input',
+    variant: 'primary',
+    rounded: 'lg',
+    size: 'md',
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-sm">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const TextInput: Story = {
+  args: {
+    type: 'text',
+    placeholder: 'Enter your text',
+  },
+};
+
+export const PasswordInput: Story = {
+  args: {
+    type: 'password',
+    placeholder: 'Enter your password',
+  },
+};
+
+export const EmailInput: Story = {
+  args: {
+    type: 'email',
+    placeholder: 'Enter your email',
+  },
+};
+
+export const TextareaInput: Story = {
+  args: {
+    type: 'textarea',
+    placeholder: 'Enter your message',
+    className: 'h-32', // 텍스트 에어리어 높이 조정
+  },
+};
+
+export const LargeRoundedInput: Story = {
+  args: {
+    type: 'text',
+    placeholder: 'Large and rounded',
+    size: 'lg',
+    rounded: 'full',
+  },
+};
+
+export const SmallInput: Story = {
+  args: {
+    type: 'text',
+    placeholder: 'Small input',
+    size: 'sm',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    type: 'text',
+    placeholder: 'Input with error',
+    error: 'This field is required',
+    className: 'border-red-500', // 에러 시 빨간 테두리
+  },
+};

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,16 +1,15 @@
-import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/solid'; // Heroicon 사용
+import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/solid';
 import { cva, VariantProps } from 'class-variance-authority';
-import React, { useState } from 'react';
+import React from 'react';
 import { cn } from '~/utils/classname';
 
-type InputProps = Readonly<
-  React.ComponentProps<'div'> & // div props 상속
-    VariantProps<typeof InputVariant> & {
-      type?: 'text' | 'password' | 'email' | 'textarea';
-      error?: string;
-      placeholder?: string;
-    }
->;
+type InputProps = VariantProps<typeof InputVariant> & {
+  className?: React.ComponentProps<'div'>['className'];
+  value: string;
+  onValueChange: (value: string) => void;
+  type?: 'text' | 'password' | 'email' | 'textarea';
+  placeholder?: string;
+};
 
 const InputVariant = cva(
   'w-full text-left font-bold focus:border focus:border-red focus:outline-none',
@@ -39,48 +38,54 @@ const InputVariant = cva(
 );
 
 const Input: React.FC<InputProps> = ({
-  type = 'text',
   className,
+  value,
+  onValueChange,
+  type = 'text',
   placeholder,
   ...props
 }) => {
-  const [showPassword, setShowPassword] = useState(false);
+  const [showPassword, setShowPassword] = React.useState(false);
   const inputClassName = cn(InputVariant(props), className);
-
-  const togglePasswordVisibility = () => setShowPassword((prev) => !prev);
+  const handlePasswordVisibility = () => setShowPassword((prev) => !prev);
 
   return (
-    <div className={cn('w-full', className)} {...props}>
-      <div className="relative">
-        {type === 'textarea' ? (
-          <textarea
-            placeholder={placeholder}
-            className={cn(inputClassName, 'resize-none')}
-          />
-        ) : (
-          <input
-            type={type === 'password' && showPassword ? 'text' : type}
-            placeholder={placeholder}
-            className={inputClassName}
-          />
-        )}
-        {type === 'password' && (
-          <button
-            type="button"
-            onClick={togglePasswordVisibility}
-            className="absolute inset-y-0 right-3 flex items-center text-gray-500"
-            aria-label={showPassword ? 'Hide password' : 'Show password'}
-          >
-            {showPassword ? (
-              <EyeIcon className="size-5" />
-            ) : (
-              <EyeSlashIcon className="size-5" />
-            )}
-          </button>
-        )}
-      </div>
+    <div className={cn('relative w-full', className)} {...props}>
+      {type === 'textarea' ? (
+        <textarea
+          className={cn(inputClassName, 'resize-none')}
+          placeholder={placeholder}
+        />
+      ) : (
+        <input
+          className={inputClassName}
+          type={type === 'password' && showPassword ? 'text' : type}
+          value={value}
+          placeholder={placeholder}
+          onChange={handleValueChange}
+        />
+      )}
+
+      {type === 'password' && (
+        <button
+          className="absolute inset-y-0 right-3 flex items-center text-gray-500"
+          type="button"
+          aria-label={showPassword ? 'Hide password' : 'Show password'}
+          onClick={handlePasswordVisibility}
+        >
+          {showPassword ? (
+            <EyeIcon className="size-5" />
+          ) : (
+            <EyeSlashIcon className="size-5" />
+          )}
+        </button>
+      )}
     </div>
   );
+
+  function handleValueChange(event: React.ChangeEvent<HTMLInputElement>) {
+    onValueChange(event.target.value);
+  }
 };
 
 export default Input;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,0 +1,87 @@
+import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/solid'; // Heroicon 사용
+import { cva, VariantProps } from 'class-variance-authority';
+import React, { useState } from 'react';
+import { cn } from '~/utils/classname';
+
+type InputProps = Readonly<
+  React.ComponentProps<'div'> & // div props 상속
+    VariantProps<typeof InputVariant> & {
+      type?: 'text' | 'password' | 'email' | 'textarea';
+      error?: string;
+      placeholder?: string;
+    }
+>;
+
+const InputVariant = cva(
+  'w-full text-left font-bold focus:border focus:border-red focus:outline-none',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-white font-normal text-gray-1',
+      },
+      rounded: {
+        full: 'rounded-full',
+        lg: 'rounded-lg',
+        md: 'rounded-md',
+      },
+      size: {
+        lg: 'h-11 px-4 py-3.5 text-base',
+        md: 'h-10 px-3 py-2.5 text-sm',
+        sm: 'h-8 px-2 py-1.5 text-sm',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      rounded: 'lg',
+      size: 'md',
+    },
+  },
+);
+
+const Input: React.FC<InputProps> = ({
+  type = 'text',
+  className,
+  placeholder,
+  ...props
+}) => {
+  const [showPassword, setShowPassword] = useState(false);
+  const inputClassName = cn(InputVariant(props), className);
+
+  const togglePasswordVisibility = () => setShowPassword((prev) => !prev);
+
+  return (
+    <div className={cn('w-full', className)} {...props}>
+      <div className="relative">
+        {type === 'textarea' ? (
+          <textarea
+            placeholder={placeholder}
+            className={cn(inputClassName, 'resize-none')}
+          />
+        ) : (
+          <input
+            type={type === 'password' && showPassword ? 'text' : type}
+            placeholder={placeholder}
+            className={inputClassName}
+          />
+        )}
+        {type === 'password' && (
+          <button
+            type="button"
+            onClick={togglePasswordVisibility}
+            className="absolute inset-y-0 right-3 flex items-center text-gray-500"
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
+          >
+            {showPassword ? (
+              <EyeIcon className="size-5" />
+            ) : (
+              <EyeSlashIcon className="size-5" />
+            )}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Input;
+export type { InputProps };

--- a/src/components/Input/LabelInput.stories.tsx
+++ b/src/components/Input/LabelInput.stories.tsx
@@ -1,0 +1,109 @@
+import { Meta, StoryObj } from '@storybook/react';
+import LabelInput from '~/components/Input/LabelInput';
+
+const meta: Meta<typeof LabelInput> = {
+  title: 'Molecules/LabelInput',
+  component: LabelInput,
+  argTypes: {
+    label: {
+      description: '라벨 텍스트',
+      control: 'text',
+    },
+    type: {
+      description: 'input 타입',
+      control: 'select',
+      options: ['text', 'password', 'email', 'textarea'],
+    },
+    labelsize: {
+      description: '라벨 크기',
+      control: 'select',
+      options: ['lg', 'md', 'sm'],
+    },
+    size: {
+      description: 'input 크기',
+      control: 'select',
+      options: ['lg', 'md', 'sm'],
+    },
+    error: {
+      description: '에러 메시지',
+      control: 'text',
+    },
+    placeholder: {
+      description: 'placeholder 텍스트',
+      control: 'text',
+    },
+  },
+  args: {
+    label: 'Label',
+    type: 'text',
+    labelsize: 'md',
+    size: 'md',
+    placeholder: 'Placeholder',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LabelInput>;
+
+export const Default: Story = {
+  args: {
+    label: 'Label',
+    type: 'text',
+    labelsize: 'md',
+    size: 'md',
+    placeholder: 'Placeholder',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    label: 'error',
+    type: 'text',
+    size: 'md',
+    labelsize: 'lg',
+    placeholder: 'Placeholder',
+    error: '에러 메시지',
+  },
+};
+
+export const Textarea: Story = {
+  args: {
+    label: 'Label',
+    type: 'textarea',
+    size: 'md',
+    labelsize: 'md',
+    placeholder: 'Placeholder',
+  },
+};
+
+export const Password: Story = {
+  args: {
+    label: '비밀번호 입력',
+    type: 'password',
+    size: 'md',
+    labelsize: 'md',
+    placeholder: '비밀번호를 입력하세요.',
+  },
+};
+
+export const PasswordError: Story = {
+  args: {
+    label: '에러메시지 있는 비밀번호 입력',
+    type: 'password',
+    size: 'md',
+    labelsize: 'md',
+    placeholder: '비밀번호를 입력하세요.',
+    error: '비밀번호가 일치하지 않습니다.',
+  },
+};
+
+export const Email: Story = {
+  args: {
+    label: '이메일',
+    type: 'email',
+    size: 'md',
+    labelsize: 'md',
+    placeholder: '이메일을 입력하세요.',
+  },
+};

--- a/src/components/Input/LabelInput.tsx
+++ b/src/components/Input/LabelInput.tsx
@@ -1,0 +1,61 @@
+import { cva, VariantProps } from 'class-variance-authority';
+import { cn } from '~/utils/classname';
+import Input from './Input';
+
+type LabelInputProps = Readonly<
+  React.ComponentProps<'div'> & // div props 상속
+    VariantProps<typeof LabelInputVariant> & {
+      label: string;
+      type?: 'text' | 'password' | 'email' | 'textarea';
+      placeholder?: string;
+      size?: 'lg' | 'md' | 'sm';
+      labelsize?: 'lg' | 'md' | 'sm';
+      rounded?: 'full' | 'md';
+      error?: string;
+    }
+>;
+
+const LabelInputVariant = cva('w-full text-left', {
+  variants: {
+    variants: {
+      primary: 'mb-1.5 font-normal text-gray-1',
+    },
+    labelsize: {
+      lg: 'text-lg',
+      md: 'text-base',
+      sm: 'text-sm',
+    },
+  },
+  defaultVariants: {
+    variants: 'primary',
+    labelsize: 'md',
+  },
+});
+
+const LabelInput: React.FC<LabelInputProps> = ({
+  label,
+  type,
+  size,
+  labelsize,
+  rounded,
+  placeholder,
+  error,
+  className,
+  ...props
+}) => {
+  return (
+    <div className={cn(`(LabelInputVariant) w-full`, className)} {...props}>
+      <label className={cn(LabelInputVariant({ labelsize }))}>{label}</label>
+      <Input
+        type={type}
+        size={size}
+        rounded={rounded}
+        error={error}
+        placeholder={placeholder}
+      />
+      {error && <p className="mt-1.5 text-sm text-red">{error}</p>}
+    </div>
+  );
+};
+
+export default LabelInput;

--- a/src/components/Input/LabelInput.tsx
+++ b/src/components/Input/LabelInput.tsx
@@ -1,19 +1,6 @@
 import { cva, VariantProps } from 'class-variance-authority';
 import { cn } from '~/utils/classname';
-import Input from './Input';
-
-type LabelInputProps = Readonly<
-  React.ComponentProps<'div'> & // div props 상속
-    VariantProps<typeof LabelInputVariant> & {
-      label: string;
-      type?: 'text' | 'password' | 'email' | 'textarea';
-      placeholder?: string;
-      size?: 'lg' | 'md' | 'sm';
-      labelsize?: 'lg' | 'md' | 'sm';
-      rounded?: 'full' | 'md';
-      error?: string;
-    }
->;
+import Input, { InputProps } from './Input';
 
 const LabelInputVariant = cva('w-full text-left', {
   variants: {
@@ -32,27 +19,25 @@ const LabelInputVariant = cva('w-full text-left', {
   },
 });
 
+type LabelInputProps = VariantProps<typeof LabelInputVariant> &
+  InputProps & {
+    className?: React.ComponentProps<'div'>['className'];
+    label: string;
+    labelsize?: 'lg' | 'md' | 'sm';
+    error?: string;
+  };
+
 const LabelInput: React.FC<LabelInputProps> = ({
-  label,
-  type,
-  size,
-  labelSize,
-  rounded,
-  placeholder,
-  error,
   className,
+  label,
+  labelSize,
+  error,
   ...props
 }) => {
   return (
-    <div className={cn(`w-full`, className)} {...props}>
+    <div className={cn(`w-full`, className)}>
       <label className={cn(LabelInputVariant({ labelSize }))}>{label}</label>
-      <Input
-        type={type}
-        size={size}
-        rounded={rounded}
-        error={error}
-        placeholder={placeholder}
-      />
+      <Input {...props} />
       {error && <p className="mt-1.5 text-sm text-red">{error}</p>}
     </div>
   );

--- a/src/components/Input/LabelInput.tsx
+++ b/src/components/Input/LabelInput.tsx
@@ -17,18 +17,18 @@ type LabelInputProps = Readonly<
 
 const LabelInputVariant = cva('w-full text-left', {
   variants: {
-    variants: {
+    variant: {
       primary: 'mb-1.5 font-normal text-gray-1',
     },
-    labelsize: {
+    labelSize: {
       lg: 'text-lg',
       md: 'text-base',
       sm: 'text-sm',
     },
   },
   defaultVariants: {
-    variants: 'primary',
-    labelsize: 'md',
+    variant: 'primary',
+    labelSize: 'md',
   },
 });
 
@@ -36,7 +36,7 @@ const LabelInput: React.FC<LabelInputProps> = ({
   label,
   type,
   size,
-  labelsize,
+  labelSize,
   rounded,
   placeholder,
   error,
@@ -44,8 +44,8 @@ const LabelInput: React.FC<LabelInputProps> = ({
   ...props
 }) => {
   return (
-    <div className={cn(`(LabelInputVariant) w-full`, className)} {...props}>
-      <label className={cn(LabelInputVariant({ labelsize }))}>{label}</label>
+    <div className={cn(`w-full`, className)} {...props}>
+      <label className={cn(LabelInputVariant({ labelSize }))}>{label}</label>
       <Input
         type={type}
         size={size}

--- a/src/components/Input/index.ts
+++ b/src/components/Input/index.ts
@@ -1,0 +1,3 @@
+import Input from '../Input/Input';
+import LabelInput from '../Input/LabelInput';
+export { Input, LabelInput };


### PR DESCRIPTION
## 📌 PR Summary

> 입력 컴포넌트와 입력컴포넌트가 들어간 레이블 컴포넌트를 만들었습니다. 입력 레이블 구현할 때 사용 + 다방면으로 사용가능.

<img width="484" alt="스크린샷 2025-01-05 오전 2 08 17" src="https://github.com/user-attachments/assets/550614fd-3db6-47db-b666-af10554a55f6" />



## 🤔 NOTE

> 스토리북도 만들었습니다. components의 Input폴더만 확인 해주시면 됩니다.



## 🔗 Related Issues
 x
