### PR TITLE
64 react stomp hooks 대신 rx stomp 로 변경한다

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,7 @@ const nextConfig: NextConfig = {
   env: {
     API_URL: CONFIGS.API_URL,
     DEV_API_URL: CONFIGS.DEV_API_URL,
+    WS_URL: CONFIGS.WS_URL,
   },
 };
 

--- a/src/app/[locale]/(authentication)/account/sign-in/page.tsx
+++ b/src/app/[locale]/(authentication)/account/sign-in/page.tsx
@@ -2,7 +2,7 @@
 
 import { type AxiosError } from 'axios';
 import { useForm } from 'react-hook-form';
-import { useSignInMutation } from '~/hooks/account';
+import { useSignIn } from '~/hooks/account';
 import { useRouter } from '~/i18n/routing';
 import { useAccount } from '~/providers/AccountProvider';
 import type { SignInForm, SignInResponse } from '~/types/account';
@@ -12,7 +12,7 @@ const SignInPage = () => {
   const router = useRouter();
   const { setAccount } = useAccount();
 
-  const { signIn } = useSignInMutation({
+  const { signIn } = useSignIn({
     onSuccess: handleSignInSuccess,
     onError: handleSignInError,
   });

--- a/src/app/[locale]/(authentication)/account/sign-up/page.tsx
+++ b/src/app/[locale]/(authentication)/account/sign-up/page.tsx
@@ -2,7 +2,7 @@
 
 import { type AxiosError } from 'axios';
 import { useForm } from 'react-hook-form';
-import { useSignUpMutation } from '~/hooks/account';
+import { useSignUp } from '~/hooks/account';
 import { useRouter } from '~/i18n/routing';
 import { SignUpForm } from '~/types/account';
 
@@ -10,7 +10,7 @@ const SignUpPage = () => {
   const { register, handleSubmit } = useForm<SignUpForm>();
   const router = useRouter();
 
-  const { signUp } = useSignUpMutation({
+  const { signUp } = useSignUp({
     onSuccess: handleSignUpSuccess,
     onError: handleSignUpError,
   });

--- a/src/app/[locale]/(main)/(game)/rooms/[id]/page.tsx
+++ b/src/app/[locale]/(main)/(game)/rooms/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from 'next-intl';
 import React from 'react';
 import LoadingIndicator from '~/components/LoadingIndicator';
 import Room from '~/components/Room';
-import { useJoinRoomMutation } from '~/hooks/room';
+import { useJoinRoom } from '~/hooks/room';
 import { GameProvider } from '~/providers/GameProvider';
 import { RoomProvider } from '~/providers/RoomProvider';
 
@@ -14,9 +14,9 @@ type Props = {
 
 const RoomPage: React.FC<Props> = ({ params }) => {
   const t = useTranslations('roomRoute');
-  const { id: roomId } = React.use(params);
-  const { isSuccess, isPending, data } = useJoinRoomMutation({
-    variables: { id: roomId },
+  const { id } = React.use(params);
+  const { isSuccess, isPending, data } = useJoinRoom({
+    variables: { id },
   });
 
   return (
@@ -26,6 +26,7 @@ const RoomPage: React.FC<Props> = ({ params }) => {
       )}
       {isSuccess && (
         <RoomProvider
+          id={id}
           title={data.name}
           hostNickname={data.owner}
           chatLogs={data.chatLogs}

--- a/src/app/[locale]/(main)/layout.tsx
+++ b/src/app/[locale]/(main)/layout.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from 'next-intl';
 import React from 'react';
 import toast from 'react-hot-toast';
 import LoadingIndicator from '~/components/LoadingIndicator';
-import { useAuthenticateMutation } from '~/hooks/account';
+import { useAuthenticate } from '~/hooks/account';
 import { useRouter } from '~/i18n/routing';
 import { useAccount } from '~/providers/AccountProvider';
 import StompProvider from '~/providers/StompProvider';
@@ -12,7 +12,7 @@ import { AuthenticateResponse } from '~/types/account';
 import { A_SECOND } from '~/utils/constants';
 
 const MainLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
-  const { isSuccess } = useAuthenticateMutation({
+  const { isSuccess } = useAuthenticate({
     sleepSeconds: 1,
     onSuccess: handleAuthenticateSuccess,
     onError: handleAuthenticateError,

--- a/src/components/BrandModal/CreateRoomModal.tsx
+++ b/src/components/BrandModal/CreateRoomModal.tsx
@@ -2,7 +2,7 @@ import { useTranslations } from 'next-intl';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { BrandModal, BrandModalProps } from '~/components/BrandModal';
-import { useCreateRoomMutation } from '~/hooks/room';
+import { useCreateRoom } from '~/hooks/room';
 import { useRouter } from '~/i18n/routing';
 import type { CreateRoomForm, CreateRoomResponse } from '~/types/room';
 
@@ -12,7 +12,7 @@ const CreateRoomModal: React.FC<Props> = ({ onClose, visible }) => {
   const t = useTranslations('createRoomModal');
   const router = useRouter();
   const { register, handleSubmit } = useForm<CreateRoomForm>();
-  const { createRoom } = useCreateRoomMutation({
+  const { createRoom } = useCreateRoom({
     onSuccess: handleRedirectOnSuccess,
   });
 

--- a/src/components/ChatBar/RoomChatBar.tsx
+++ b/src/components/ChatBar/RoomChatBar.tsx
@@ -1,10 +1,10 @@
 import { noop } from 'lodash-es';
-import { useParams } from 'next/navigation';
 import React from 'react';
 import { useStompClient } from 'react-stomp-hooks';
 import { ChatBar } from '~/components/ChatBar';
 import { TextareaHandle } from '~/components/CustomTextarea';
 import { useSessionId } from '~/hooks/account';
+import { useRoom } from '~/hooks/room';
 import { cn } from '~/utils/classname';
 
 type Props = {
@@ -15,8 +15,9 @@ type Props = {
 const RoomChatBar = React.memo<Props>(({ className, renderPlaceholder }) => {
   const textareaRef = React.useRef<TextareaHandle>(null);
   const stompClient = useStompClient();
-  const { id } = useParams<{ id: string }>();
+
   const sessionId = useSessionId();
+  const { id } = useRoom();
 
   return (
     <>

--- a/src/components/ChatMessage/ChatMessage.tsx
+++ b/src/components/ChatMessage/ChatMessage.tsx
@@ -15,7 +15,7 @@ type Props = {
 const ChatMessage = React.memo<Props>(
   ({ className, position, username, message, isCumulative, color, src }) => {
     return (
-      <div
+      <li
         className={cn(
           'flex gap-x-1',
           position === 'right' && 'justify-end',
@@ -43,7 +43,7 @@ const ChatMessage = React.memo<Props>(
             {message}
           </div>
         </div>
-      </div>
+      </li>
     );
   },
 );

--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -1,10 +1,9 @@
-import { useParams } from 'next/navigation';
 import React from 'react';
 import { RoomChatBar } from '~/components/ChatBar';
 import RoomHeader from '~/components/RoomHeader/RoomHeader';
 import RoomMessages from '~/components/RoomMessages';
 import RoomUserList from '~/components/RoomUserList';
-import { useRoomSystemNoticeSubscription } from '~/hooks/room';
+import { useRoom, useRoomSystemNotice } from '~/hooks/room';
 import { cn } from '~/utils/classname';
 
 type Props = {
@@ -12,18 +11,17 @@ type Props = {
 };
 
 const Room: React.FC<Props> = ({ className }) => {
-  const { id } = useParams<{ id: string }>();
-  const [isStarted, setIsStarted] = React.useState(false);
+  const { id, isPlaying, setIsPlaying } = useRoom();
 
-  useRoomSystemNoticeSubscription({
+  useRoomSystemNotice({
     variables: { id },
     onGameStart: handleGameStart,
   });
 
   return (
     <div className={cn('flex h-full flex-col', className)}>
-      <RoomHeader className="shrink-0" isStarted={isStarted} />
-      {!isStarted && <RoomUserList />}
+      <RoomHeader className="shrink-0" />
+      {!isPlaying && <RoomUserList />}
       <RoomMessages className="flex-1" />
       <RoomChatBar
         className="bottom-0-dynamic fixed w-full"
@@ -33,7 +31,7 @@ const Room: React.FC<Props> = ({ className }) => {
   );
 
   function handleGameStart() {
-    setIsStarted(true);
+    setIsPlaying(true);
   }
 };
 

--- a/src/components/RoomHeader/RoomHeader.tsx
+++ b/src/components/RoomHeader/RoomHeader.tsx
@@ -1,26 +1,18 @@
 import React from 'react';
-import { ChatRoom } from '~/types/chat';
+import { useRoom } from '~/hooks/room';
 import { cn } from '~/utils/classname';
 import RoomHeaderPlaying from './RoomHeaderPlaying';
 import RoomHeaderWaiting from './RoomHeaderWaiting';
-
 type Props = {
   className?: string;
-  isStarted: boolean;
 };
 
-const RoomHeader = React.memo<Props>(({ className, isStarted }) => {
+const RoomHeader = React.memo<Props>(({ className }) => {
+  const { isPlaying } = useRoom();
+
   return (
     <div className={cn('', className)}>
-      {!isStarted ? (
-        <RoomHeaderWaiting />
-      ) : (
-        <RoomHeaderPlaying
-          nthRound={1}
-          isMorning={false}
-          chatRoomKind={ChatRoom.All}
-        />
-      )}
+      {!isPlaying ? <RoomHeaderWaiting /> : <RoomHeaderPlaying />}
     </div>
   );
 });

--- a/src/components/RoomHeader/RoomHeaderPlaying.tsx
+++ b/src/components/RoomHeader/RoomHeaderPlaying.tsx
@@ -2,84 +2,90 @@ import { Button as HeadlessuiButton } from '@headlessui/react';
 import { MinusIcon, PlusIcon } from '@heroicons/react/24/outline';
 import { useTranslations } from 'next-intl';
 import React from 'react';
+import { useRoom } from '~/hooks/room';
+import { useGame } from '~/providers/GameProvider';
 import CartFillIcon from '~/svgs/CartFillIcon';
 import ChatIcon from '~/svgs/ChatIcon';
-import { ChatRoom } from '~/types/chat';
+import { GameTime } from '~/types/game';
 import { cn } from '~/utils/classname';
 
 type Props = {
   className?: string;
-  nthRound: number;
-  isMorning: boolean;
-  chatRoomKind: ChatRoom;
 };
 
-const RoomHeaderPlaying = React.memo<Props>(
-  ({ className, nthRound, isMorning, chatRoomKind }) => {
-    const t = useTranslations('roomRoute');
+const RoomHeaderPlaying = React.memo<Props>(({ className }) => {
+  const t = useTranslations('roomRoute');
+  const { nthDay, time } = useGame();
+  const { currentChatRoom } = useRoom();
 
-    return (
-      <header
-        className={cn(
-          'bg-gray-3 relative flex h-[5.5rem] items-center justify-between px-4',
-          className,
-        )}
-      >
-        <div className="z-10 flex items-center gap-x-2">
-          <p className="text-2xl font-semibold">
-            {`${nthRound}${t('header.nth')} ${isMorning ? t('header.morning') : t('header.night')}`}
-          </p>
+  const timeLabel =
+    time === GameTime.Morning
+      ? t('header.morning')
+      : time === GameTime.Night
+        ? t('header.night')
+        : '';
 
-          <p className="text-sm">
-            {t(`chatRoomType.${chatRoomKind}`, { username: 'jeheecheon' })}
-          </p>
-        </div>
+  return (
+    <header
+      className={cn(
+        'bg-gray-3 relative flex h-[5.5rem] items-center justify-between px-4',
+        className,
+      )}
+    >
+      <div className="z-10 flex items-center gap-x-2">
+        <p className="text-2xl font-semibold">
+          {`${nthDay}${t('header.nth')} ${timeLabel}`}
+        </p>
 
-        <div className="z-10 flex items-center gap-x-6">
-          <span className="text-lg font-bold">₩10</span>
+        <p className="text-sm">
+          {t(`chatRoomType.${currentChatRoom}`, { username: 'jeheecheon' })}
+        </p>
+      </div>
 
-          <HeadlessuiButton>
-            <CartFillIcon className="fill-gray-1 size-6" />
-          </HeadlessuiButton>
+      <div className="z-10 flex items-center gap-x-6">
+        <span className="text-lg font-bold">₩10</span>
 
-          <HeadlessuiButton>
-            <ChatIcon className="fill-gray-1 size-6" />
-          </HeadlessuiButton>
-        </div>
+        <HeadlessuiButton>
+          <CartFillIcon className="fill-gray-1 size-6" />
+        </HeadlessuiButton>
 
-        <BottomShadow />
+        <HeadlessuiButton>
+          <ChatIcon className="fill-gray-1 size-6" />
+        </HeadlessuiButton>
+      </div>
 
-        <div className="bg-gray-3 absolute bottom-0 left-1/2 z-50 flex -translate-x-1/2 translate-y-1/2 gap-x-1 rounded-full p-1">
-          <HeadlessuiButton
-            className="bg-gray-3 rounded-full drop-shadow-lg"
-            onClick={handleMinusClick}
-          >
-            <MinusIcon className="fill-gray-1 size-6" />
-          </HeadlessuiButton>
+      <BottomShadow />
 
-          <span className="bg-gray-1 flex h-5.5 w-16 items-center justify-center rounded-full text-sm text-white">
-            00:20
-          </span>
+      <div className="bg-gray-3 absolute bottom-0 left-1/2 z-50 flex -translate-x-1/2 translate-y-1/2 gap-x-1 rounded-full p-1">
+        <HeadlessuiButton
+          className="bg-gray-3 rounded-full drop-shadow-lg"
+          onClick={handleMinusClick}
+        >
+          <MinusIcon className="fill-gray-1 size-6" />
+        </HeadlessuiButton>
 
-          <HeadlessuiButton
-            className={`bg-gray-3 rounded-full drop-shadow-lg`}
-            onClick={handlePlusClick}
-          >
-            <PlusIcon className="fill-gray-1 size-6" />
-          </HeadlessuiButton>
-        </div>
-      </header>
-    );
+        <span className="bg-gray-1 flex h-5.5 w-16 items-center justify-center rounded-full text-sm text-white">
+          00:20
+        </span>
 
-    function handleMinusClick() {
-      console.log('minus');
-    }
+        <HeadlessuiButton
+          className={`bg-gray-3 rounded-full drop-shadow-lg`}
+          onClick={handlePlusClick}
+        >
+          <PlusIcon className="fill-gray-1 size-6" />
+        </HeadlessuiButton>
+      </div>
+    </header>
+  );
 
-    function handlePlusClick() {
-      console.log('plus');
-    }
-  },
-);
+  function handleMinusClick() {
+    console.log('minus');
+  }
+
+  function handlePlusClick() {
+    console.log('plus');
+  }
+});
 RoomHeaderPlaying.displayName = 'RoomHeaderPlaying';
 
 const BottomShadow: React.FC = () => (

--- a/src/components/RoomHeader/RoomHeaderWaiting.tsx
+++ b/src/components/RoomHeader/RoomHeaderWaiting.tsx
@@ -2,14 +2,12 @@ import { Button as HeadlessuiButton } from '@headlessui/react';
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 import { AxiosError } from 'axios';
 import { debounce } from 'lodash-es';
-import { useParams } from 'next/navigation';
 import React from 'react';
 import { Button } from '~/components/Button';
-import { useStartGameMutation } from '~/hooks/game';
-import { useRoomUsersNoticeSubscription } from '~/hooks/room';
+import { useStartGame } from '~/hooks/game';
+import { useRoom, useRoomUsersNotice } from '~/hooks/room';
 import { useRouter } from '~/i18n/routing';
 import { useAccount } from '~/providers/AccountProvider';
-import { useRoom } from '~/providers/RoomProvider';
 import { cn } from '~/utils/classname';
 
 type Props = {
@@ -19,9 +17,10 @@ type Props = {
 const RoomHeaderWaiting = React.memo<Props>(({ className }) => {
   const router = useRouter();
   const { account } = useAccount();
-  const { id } = useParams<{ id: string }>();
-  const { users } = useRoomUsersNoticeSubscription({ variables: { id } });
-  const { startGame, isPending, isSuccess } = useStartGameMutation({
+
+  const { id } = useRoom();
+  const { users } = useRoomUsersNotice({ variables: { id } });
+  const { startGame, isPending, isSuccess } = useStartGame({
     onError: handleStartGameError,
   });
   const { title, hostNickname } = useRoom();

--- a/src/components/RoomMessages.tsx
+++ b/src/components/RoomMessages.tsx
@@ -1,24 +1,20 @@
-import { useParams } from 'next/navigation';
 import React from 'react';
 import { ChatMessage } from '~/components/ChatMessage';
-import { useChatMessagesSubscription } from '~/hooks/chat';
+import { useChatMessages } from '~/hooks/chat';
 import { useAccount } from '~/providers/AccountProvider';
-import { ChatMessage as ChatMessageType } from '~/types/chat';
+import { ChatMessage as ChatMessageType, ChatRoom } from '~/types/chat';
 import { cn } from '~/utils/classname';
 
 type Props = {
   className?: string;
-  previousMessages?: ChatMessageType[];
 };
 
-const RoomMessages = React.memo<Props>(({ className, previousMessages }) => {
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const bottomRef = React.useRef<HTMLDivElement>(null);
+const RoomMessages = React.memo<Props>(({ className }) => {
+  const containerRef = React.useRef<HTMLUListElement>(null);
+  const bottomRef = React.useRef<HTMLLIElement>(null);
 
-  const { id } = useParams<{ id: string }>();
-  const messages = useChatMessagesSubscription({
-    url: `/topic/room/${id}/chat`,
-    previousMessages,
+  const messages = useChatMessages({
+    chatRoom: ChatRoom.All,
     onNewMessage: scrollToBottom,
   });
 
@@ -29,7 +25,7 @@ const RoomMessages = React.memo<Props>(({ className, previousMessages }) => {
   }, []);
 
   return (
-    <section
+    <ul
       className={cn('bg-gray-6 space-y-3 overflow-y-auto p-4', className)}
       ref={containerRef}
     >
@@ -42,8 +38,8 @@ const RoomMessages = React.memo<Props>(({ className, previousMessages }) => {
         />
       ))}
 
-      <div ref={bottomRef} aria-hidden />
-    </section>
+      <li ref={bottomRef} aria-hidden />
+    </ul>
   );
 
   // scroll to bottom when new message is sent

--- a/src/components/RoomUserList.tsx
+++ b/src/components/RoomUserList.tsx
@@ -1,8 +1,6 @@
 import { BookmarkIcon } from '@heroicons/react/24/outline';
-import { useParams } from 'next/navigation';
 import React from 'react';
-import { useRoomUsersNoticeSubscription } from '~/hooks/room';
-import { useRoom } from '~/providers/RoomProvider';
+import { useRoom, useRoomUsersNotice } from '~/hooks/room';
 import { cn } from '~/utils/classname';
 
 type Props = {
@@ -10,9 +8,8 @@ type Props = {
 };
 
 const RoomUserList = React.memo<Props>(({ className }) => {
-  const { id } = useParams<{ id: string }>();
-  const { users } = useRoomUsersNoticeSubscription({ variables: { id } });
-  const { hostNickname } = useRoom();
+  const { id, hostNickname } = useRoom();
+  const { users } = useRoomUsersNotice({ variables: { id } });
 
   return (
     <ul

--- a/src/hooks/account.ts
+++ b/src/hooks/account.ts
@@ -33,7 +33,7 @@ export const useSessionId = () => {
   );
 };
 
-export const useAuthenticateMutation = ({
+export const useAuthenticate = ({
   sleepSeconds = 1,
   onSuccess,
   onError,
@@ -74,7 +74,7 @@ export const useAuthenticateMutation = ({
   };
 };
 
-export const useSignInMutation = ({
+export const useSignIn = ({
   onSuccess,
   onError,
 }: {
@@ -113,7 +113,7 @@ export const useSignInMutation = ({
   };
 };
 
-export const useSignUpMutation = ({
+export const useSignUp = ({
   onSuccess,
   onError,
 }: {

--- a/src/hooks/chat.ts
+++ b/src/hooks/chat.ts
@@ -1,5 +1,5 @@
 import { useSubscription } from 'react-stomp-hooks';
-import { useRoom } from '~/providers/RoomProvider';
+import { useRoom } from '~/hooks/room';
 import { chatMessage, ChatMessage, ChatRoom } from '~/types/chat';
 
 export const useChatMessages = ({

--- a/src/hooks/chat.ts
+++ b/src/hooks/chat.ts
@@ -1,25 +1,26 @@
-import React from 'react';
 import { useSubscription } from 'react-stomp-hooks';
-import { chatMessage, ChatMessage } from '~/types/chat';
+import { useRoom } from '~/providers/RoomProvider';
+import { chatMessage, ChatMessage, ChatRoom } from '~/types/chat';
 
-export const useChatMessagesSubscription = ({
-  url,
-  previousMessages = [],
+export const useChatMessages = ({
+  chatRoom,
   onNewMessage,
 }: {
-  url: string;
-  previousMessages?: ChatMessage[];
+  chatRoom: ChatRoom;
   onNewMessage?: (message: ChatMessage) => void;
 }) => {
-  const [messages, setMessages] =
-    React.useState<ChatMessage[]>(previousMessages);
+  const { id, messagesByRoom, addMessage } = useRoom();
 
-  useSubscription(url, ({ body }) => {
+  useSubscription(getMessagesUrl(chatRoom), ({ body }) => {
     const _message = JSON.parse(body);
     const message = chatMessage.parse(_message);
-    setMessages((prev) => [...prev, message]);
+    addMessage(chatRoom, message);
     setTimeout(() => onNewMessage?.(message), 0);
   });
 
-  return messages;
+  return messagesByRoom[chatRoom];
+
+  function getMessagesUrl(chatRoom: ChatRoom) {
+    return `/topic/room/${id}/chat`;
+  }
 };

--- a/src/hooks/game.ts
+++ b/src/hooks/game.ts
@@ -9,7 +9,7 @@ import {
 } from '~/types/game';
 import { server } from '~/utils/axios';
 
-export const useStartGameMutation = ({
+export const useStartGame = ({
   onSuccess,
   onError,
 }: {
@@ -41,7 +41,7 @@ export const useStartGameMutation = ({
   };
 };
 
-export const useUserGameInfoSubscription = ({
+export const useUserGameInfo = ({
   variables: { username },
   onMessage,
 }: {

--- a/src/hooks/loading.ts
+++ b/src/hooks/loading.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useInterval } from 'react-use';
+
 export const useDotsString = ({ maxLength = 3 }: { maxLength?: number }) => {
   const [dotsCount, setDotsCount] = React.useState(0);
   useInterval(() => {

--- a/src/hooks/room.ts
+++ b/src/hooks/room.ts
@@ -8,6 +8,9 @@ import { AxiosError } from 'axios';
 import React from 'react';
 import { useSubscription } from 'react-stomp-hooks';
 import { z } from 'zod';
+import { useStore } from 'zustand';
+import { RoomStoreContext } from '~/providers/RoomProvider';
+import { RoomStore } from '~/stores/room';
 import { username } from '~/types/account';
 import {
   createRoomResponse,
@@ -21,9 +24,21 @@ import {
   type JoinRoomRequest,
   type PaginatedRoomsResponse,
 } from '~/types/room';
+import { assert } from '~/utils/assert';
 import { server } from '~/utils/axios';
 import { A_MINUTE, A_SECOND } from '~/utils/constants';
 import { sleep } from '~/utils/misc';
+
+export const useRoomStore = <T>(selector: (store: RoomStore) => T): T => {
+  const roomStoreContext = React.useContext(RoomStoreContext);
+  assert(roomStoreContext, 'useRoomStore must be used within roomProvider');
+
+  return useStore(roomStoreContext, selector);
+};
+
+export const useRoom = () => {
+  return useRoomStore((store) => store);
+};
 
 export const useInfiniteRooms = () => {
   const _queryRoomsAsync = React.useCallback(
@@ -59,7 +74,7 @@ export const useInfiniteRooms = () => {
   return { ...rest, rooms };
 };
 
-export const useJoinRoomMutation = ({
+export const useJoinRoom = ({
   variables: { id },
   onError,
 }: {
@@ -98,7 +113,7 @@ export const useJoinRoomMutation = ({
   };
 };
 
-export const useCreateRoomMutation = ({
+export const useCreateRoom = ({
   onSuccess,
 }: {
   onSuccess: (data: CreateRoomResponse, variables: CreateRoomForm) => void;
@@ -126,7 +141,7 @@ export const useCreateRoomMutation = ({
   };
 };
 
-export const useRoomUsersNoticeSubscription = ({
+export const useRoomUsersNotice = ({
   variables: { id },
 }: {
   variables: { id: string };
@@ -142,7 +157,7 @@ export const useRoomUsersNoticeSubscription = ({
   return { users };
 };
 
-export const useRoomSystemNoticeSubscription = ({
+export const useRoomSystemNotice = ({
   variables: { id },
   onGameStart,
 }: {

--- a/src/providers/GameProvider.tsx
+++ b/src/providers/GameProvider.tsx
@@ -30,3 +30,9 @@ export const useGameStore = <T,>(selector: (store: GameStore) => T): T => {
 
   return useStore(gameStoreContext, selector);
 };
+
+export const useGame = () => {
+  const gameStore = useGameStore((store) => store);
+
+  return gameStore;
+};

--- a/src/providers/RoomProvider.tsx
+++ b/src/providers/RoomProvider.tsx
@@ -1,11 +1,9 @@
 'use client';
 
 import React, { PropsWithChildren } from 'react';
-import { useStore } from 'zustand';
-import { createRoomStore, defaultInitState, RoomStore } from '~/stores/room';
-import { ChatMessage } from '~/types/chat';
+import { createRoomStore, defaultInitState } from '~/stores/room';
+import { ChatMessage, ChatRoom } from '~/types/chat';
 import { Nullable } from '~/types/misc';
-import { assert } from '~/utils/assert';
 
 export type RoomStoreApi = ReturnType<typeof createRoomStore>;
 
@@ -13,24 +11,27 @@ export const RoomStoreContext =
   React.createContext<Nullable<RoomStoreApi>>(null);
 
 type Props = {
+  id: string;
   title: string;
   hostNickname: string;
   chatLogs: ChatMessage[];
 };
 
 export const RoomProvider: React.FC<PropsWithChildren<Props>> = ({
-  children,
+  id,
   title,
   hostNickname,
   chatLogs,
+  children,
 }) => {
   const storeRef = React.useRef<RoomStoreApi>();
   if (!storeRef.current) {
     const initialState = { ...defaultInitState };
 
+    initialState.id = id;
     initialState.title = title;
     initialState.hostNickname = hostNickname;
-    initialState.messagesByRoom.All = chatLogs;
+    initialState.messagesByRoom[ChatRoom.All] = chatLogs;
 
     storeRef.current = createRoomStore(initialState);
   }
@@ -40,15 +41,4 @@ export const RoomProvider: React.FC<PropsWithChildren<Props>> = ({
       {children}
     </RoomStoreContext.Provider>
   );
-};
-
-export const useRoomStore = <T,>(selector: (store: RoomStore) => T): T => {
-  const roomStoreContext = React.useContext(RoomStoreContext);
-  assert(roomStoreContext, 'useRoomStore must be used within roomProvider');
-
-  return useStore(roomStoreContext, selector);
-};
-
-export const useRoom = () => {
-  return useRoomStore((store) => store);
 };

--- a/src/providers/StompProvider.tsx
+++ b/src/providers/StompProvider.tsx
@@ -1,6 +1,7 @@
 import React, { PropsWithChildren } from 'react';
 import { StompSessionProvider } from 'react-stomp-hooks';
 import { useSessionId } from '~/hooks/account';
+import { CONFIGS } from '~/utils/config';
 
 type Props = {
   onConnect?: () => void;
@@ -8,26 +9,21 @@ type Props = {
 };
 
 const StompProvider = React.memo<PropsWithChildren<Props>>(
-  ({ onConnect: handleConnect, onError, children }) => {
+  ({ onConnect, onError, children }) => {
     const sessionId = useSessionId();
 
     return (
       <StompSessionProvider
-        url={'ws://localhost:8080/ws'}
+        url={CONFIGS.WS_URL}
         connectHeaders={{
           Authorization: sessionId,
         }}
-        onConnect={handleConnect}
-        onWebSocketError={handleError}
+        onConnect={onConnect}
+        onWebSocketError={onError}
       >
         {children}
       </StompSessionProvider>
     );
-
-    function handleError(error: Error) {
-      console.error(error);
-      onError?.(error);
-    }
   },
 );
 StompProvider.displayName = 'StompProvider';

--- a/src/stores/room.ts
+++ b/src/stores/room.ts
@@ -1,44 +1,48 @@
 import { createStore } from 'zustand/vanilla';
-import { ChatMessage, ChatRoom, ChatRoomKey } from '~/types/chat';
+import { ChatMessage, ChatRoom } from '~/types/chat';
 
 export type RoomState = {
+  id: string;
   title: string;
   hostNickname: string;
   isPlaying: boolean;
   currentChatRoom: ChatRoom;
-  messagesByRoom: Record<ChatRoomKey, ChatMessage[]>;
+  messagesByRoom: Record<ChatRoom, ChatMessage[]>;
 };
 
 export type RoomActions = {
+  setId: (id: string) => void;
   setTitle: (title: string) => void;
   setHostNickname: (nickname: string) => void;
   setIsPlaying: (isPlaying: boolean) => void;
   setCurrentChatRoom: (chatRoom: ChatRoom) => void;
-  addMessage: (chatRoom: ChatRoomKey, message: ChatMessage) => void;
-  clearMessages: (chatRoom: ChatRoomKey) => void;
+  addMessage: (chatRoom: ChatRoom, message: ChatMessage) => void;
+  clearMessages: (chatRoom: ChatRoom) => void;
 };
 
 export type RoomStore = RoomState & RoomActions;
 
 export const defaultInitState: RoomState = {
+  id: '',
   title: '',
   hostNickname: '',
   isPlaying: false,
   currentChatRoom: ChatRoom.All,
   messagesByRoom: Object.values(ChatRoom)
-    .filter((key) => Number.isNaN(Number(key)))
+    .filter((key) => typeof ChatRoom[key as ChatRoom] === 'number')
     .reduce(
       (acc, key) => ({
         ...acc,
         [key]: [],
       }),
-      {} as Record<ChatRoomKey, ChatMessage[]>,
+      {} as Record<ChatRoom, ChatMessage[]>,
     ),
 };
 
 export const createRoomStore = (initState: RoomState = defaultInitState) => {
   return createStore<RoomStore>()((set) => ({
     ...initState,
+    setId: (id) => set({ id }),
     setTitle: (title) => set({ title }),
     setHostNickname: (hostNickname) => set({ hostNickname }),
     setIsPlaying: (isPlaying) => set({ isPlaying }),

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -16,8 +16,6 @@ export enum ChatRoom {
   Eliminated,
 }
 
-export type ChatRoomKey = keyof typeof ChatRoom;
-
 export const chatMessage = z.object({
   id: z.string(),
   content: z.string(),

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,4 +1,5 @@
 export const CONFIGS = {
   API_URL: process.env.API_URL,
   DEV_API_URL: process.env.DEV_API_URL || 'http://localhost:8080',
+  WS_URL: process.env.WS_URL || 'ws://localhost:8080/ws',
 } as const;


### PR DESCRIPTION
## 📌 PR Summary
기존 react-stomp-hooks 의 useSubscription 으로 구현 중이었으나, 게임 로직 상 conditional 하게 훅을 호출해야할 것 같아서 rx-stomp로 변경하려 했었다. 그러나 useSubscription 훅을 if 문 안에 넣지 않고도, 빈 배열을 패스해서 conditional하게 사용할 수 있는 것을 뒤늦게 알게 됨......

이번 pr은 그냥 작성했던 hook들 모두 이름 변경하고, global context로 state를 위쪽으로 올린 것들 컴포넌트에서 사용하는 로직 추가하였음.

## 🔗 Related Issues
 #64
